### PR TITLE
Return error as json, not dict

### DIFF
--- a/calico_cni/calico_cni.py
+++ b/calico_cni/calico_cni.py
@@ -370,13 +370,16 @@ class CniPlugin(object):
             except CniError as e:
                 # We hit a CNI error - return the appropriate CNI formatted
                 # error dictionary.
-                response = {"code": e.code, "msg": e.msg, "details": e.details}
+                response = json.dumps({"code": e.code, 
+                                       "msg": e.msg, 
+                                       "details": e.details})
                 code = e.code
         else:
             _log.debug("Using binary plugin")
             code, response = self._call_binary_ipam_plugin(env)
 
         # Return the IPAM return code and output.
+        _log.debug("IPAM response (rc=%s): %s", code, response)
         return code, response
 
     def _call_binary_ipam_plugin(self, env):

--- a/calico_cni/tests/unit/test_cni_plugin.py
+++ b/calico_cni/tests/unit/test_cni_plugin.py
@@ -471,7 +471,7 @@ class CniPluginTest(unittest.TestCase):
         rc, result = self.plugin._call_ipam_plugin(env)
 
         # Assert.
-        expected = {"code": 150, "msg": "message", "details": "details"}
+        expected = '{"msg": "message", "code": 150, "details": "details"}'
         assert_equal(rc, 150)
         assert_equal(result, expected)
 


### PR DESCRIPTION
Also run FVs against inline IPAM plugin.