### PR TITLE
Don't assign IPv6 address when using calico-ipam

### DIFF
--- a/ipam.py
+++ b/ipam.py
@@ -62,11 +62,10 @@ class IpamPlugin(object):
         if self.command == "ADD":
             # Assign an IP address for this container.
             _log.info("Assigning address to container %s", self.container_id)
-            ipv4, ipv6 = self._assign_address(handle_id=self.container_id)
+            ipv4, _ = self._assign_address(handle_id=self.container_id)
     
             # Output the response and exit successfully.
-            return json.dumps({"ip4": {"ip": str(ipv4.cidr)},
-                               "ip6": {"ip": str(ipv6.cidr)}})
+            return json.dumps({"ip4": {"ip": str(ipv4.cidr)}})
         else:
             # Release IPs using the container_id as the handle.
             _log.info("Releasing addresses on container %s", 
@@ -87,7 +86,7 @@ class IpamPlugin(object):
         ipv6 = IPNetwork("::") 
         try:
             ipv4_addrs, ipv6_addrs = self.datastore_client.auto_assign_ips(
-                num_v4=1, num_v6=1, handle_id=handle_id, attributes=None,
+                num_v4=1, num_v6=0, handle_id=handle_id, attributes=None,
             )
             _log.debug("Allocated ip4s: %s, ip6s: %s", ipv4_addrs, ipv6_addrs)
         except RuntimeError as e:
@@ -102,15 +101,9 @@ class IpamPlugin(object):
                 _log.error("No IPv4 address returned, exiting")
                 raise CniError(ERR_CODE_GENERIC,
                                msg="No IPv4 addresses available in pool")
-            try:
-                ipv6 = ipv6_addrs[0]
-            except IndexError:
-                _log.error("No IPv6 address returned, exiting")
-                raise CniError(ERR_CODE_GENERIC,
-                               msg="No IPv6 addresses available in pool")
 
             _log.info("Assigned IPv4: %s, IPv6: %s", ipv4, ipv6)
-            return IPNetwork(ipv4), IPNetwork(ipv6)
+            return IPNetwork(ipv4), None
 
     def _parse_environment(self, env):
         """

--- a/tests/fv/test_calico_cni.py
+++ b/tests/fv/test_calico_cni.py
@@ -128,9 +128,7 @@ class CniPluginFvTest(unittest.TestCase):
         # Configure.
         self.command = CNI_CMD_ADD
         ip4 = "10.0.0.1/32"
-        ip6 = "0:0:0:0:0:ffff:a00:1"
-        ipam_stdout = json.dumps({"ip4": {"ip": ip4}, 
-                                  "ip6": {"ip": ip6}})
+        ipam_stdout = json.dumps({"ip4": {"ip": ip4}})
         self.set_ipam_result(0, ipam_stdout, "")
 
         # Create plugin.
@@ -150,7 +148,7 @@ class CniPluginFvTest(unittest.TestCase):
 
         # Assert an endpoint was created.
         self.client.create_endpoint.assert_called_once_with(ANY, 
-                "cni", self.container_id, [IPNetwork(ip4), IPNetwork(ip6)])
+                "cni", self.container_id, [IPNetwork(ip4)])
 
         # Assert a profile was applied.
         self.client.append_profiles_to_endpoint.assert_called_once_with(
@@ -166,9 +164,7 @@ class CniPluginFvTest(unittest.TestCase):
         self.cni_args = "K8S_POD_NAME=podname;K8S_POD_NAMESPACE=default"
         self.command = CNI_CMD_ADD
         ip4 = "10.0.0.1/32"
-        ip6 = "0:0:0:0:0:ffff:a00:1"
-        ipam_stdout = json.dumps({"ip4": {"ip": ip4}, 
-                                  "ip6": {"ip": ip6}})
+        ipam_stdout = json.dumps({"ip4": {"ip": ip4}})
         self.set_ipam_result(0, ipam_stdout, "")
 
         # Set up docker client response.
@@ -193,7 +189,7 @@ class CniPluginFvTest(unittest.TestCase):
 
         # Assert an endpoint was created.
         self.client.create_endpoint.assert_called_once_with(ANY, 
-                "cni", self.container_id, [IPNetwork(ip4),IPNetwork(ip6)])
+                "cni", self.container_id, [IPNetwork(ip4)])
 
         # Assert a profile was applied.
         self.client.append_profiles_to_endpoint.assert_called_once_with(
@@ -210,9 +206,7 @@ class CniPluginFvTest(unittest.TestCase):
         self.cni_args = "K8S_POD_NAME=podname;K8S_POD_NAMESPACE=defaultns"
         self.command = CNI_CMD_ADD
         ip4 = "10.0.0.1/32"
-        ip6 = "0:0:0:0:0:ffff:a00:1"
-        ipam_stdout = json.dumps({"ip4": {"ip": ip4}, 
-                                  "ip6": {"ip": ip6}})
+        ipam_stdout = json.dumps({"ip4": {"ip": ip4}})
         self.set_ipam_result(0, ipam_stdout, "")
         self.policy = {"type": "k8s-annotations"}
 
@@ -248,7 +242,7 @@ class CniPluginFvTest(unittest.TestCase):
 
         # Assert an endpoint was created.
         self.client.create_endpoint.assert_called_once_with(ANY, 
-                "cni", self.container_id, [IPNetwork(ip4), IPNetwork(ip6)])
+                "cni", self.container_id, [IPNetwork(ip4)])
 
         # Assert profile was created.
         self.client.create_profile.assert_called_once_with(
@@ -439,9 +433,7 @@ class CniPluginFvTest(unittest.TestCase):
         # Configure.
         self.command = CNI_CMD_ADD
         ip4 = "10.0.0.1/32"
-        ip6 = "0:0:0:0:0:ffff:a00:1"
-        ipam_stdout = json.dumps({"ip4": {"ip": ip4}, 
-                                  "ip6": {"ip": ip6}})
+        ipam_stdout = json.dumps({"ip4": {"ip": ip4}})
         self.set_ipam_result(0, ipam_stdout, "")
 
         # Create plugin.
@@ -463,7 +455,7 @@ class CniPluginFvTest(unittest.TestCase):
 
         # Assert an endpoint was created.
         self.client.create_endpoint.assert_called_once_with(ANY, 
-                "cni", self.container_id, [IPNetwork(ip4), IPNetwork(ip6)])
+                "cni", self.container_id, [IPNetwork(ip4)])
 
         # Assert set_profile called by policy driver.
         self.client.append_profiles_to_endpoint.assert_called_once_with(
@@ -533,10 +525,8 @@ class CniPluginFvWithIpamTest(CniPluginFvTest):
         if stdout and not rc:
             # A successful add response.
             ip4 = json.loads(stdout)["ip4"]["ip"]
-            ip6 = json.loads(stdout)["ip6"]["ip"]
             ip4s = [ip4] if ip4 else []
-            ip6s = [ip6] if ip6 else []
-            self.m_ipam_plugin_client().auto_assign_ips.return_value = ip4s, ip6s
+            self.m_ipam_plugin_client().auto_assign_ips.return_value = ip4s, None
  
     def test_add_ipam_error(self):
         # Mock out auto_assign_ips to throw an error.

--- a/tests/unit/test_ipam.py
+++ b/tests/unit/test_ipam.py
@@ -67,16 +67,14 @@ class CniIpamTest(unittest.TestCase):
         # Mock
         self.plugin.command = CNI_CMD_ADD
         ip4 = IPNetwork("1.2.3.4/32")
-        ip6 = IPNetwork("ba:ad::be:ef/128")
         self.plugin._assign_address = MagicMock(spec=self.plugin._assign_address)
-        self.plugin._assign_address.return_value = ip4, ip6
+        self.plugin._assign_address.return_value = ip4, None
 
         # Call 
         ret = self.plugin.execute()
 
         # Assert
-        expected = json.dumps({"ip4": {"ip": "1.2.3.4/32"}, 
-                               "ip6": {"ip": "ba:ad::be:ef/128"}})
+        expected = json.dumps({"ip4": {"ip": "1.2.3.4/32"}})
         assert_equal(ret, expected)
 
     @patch('sys.stdout', new_callable=StringIO)
@@ -108,19 +106,17 @@ class CniIpamTest(unittest.TestCase):
     def test_assign_address_mainline(self):
         # Mock
         ip4 = IPNetwork("1.2.3.4/32")
-        ip6 = IPNetwork("ba:ad::be:ef/128")
         self.plugin.datastore_client.auto_assign_ips = MagicMock(spec=self.plugin._assign_address)
-        self.plugin.datastore_client.auto_assign_ips.return_value = [ip4], [ip6]
+        self.plugin.datastore_client.auto_assign_ips.return_value = [ip4], []
 
         # Args
         handle_id = "abcdef12345"
 
         # Call
-        ret_ip4, ret_ip6 = self.plugin._assign_address(handle_id)
+        ret_ip4, _ = self.plugin._assign_address(handle_id)
 
         # Assert
         assert_equal(ip4, ret_ip4)
-        assert_equal(ip6, ret_ip6)
 
     def test_assign_address_runtime_err(self):
         # Mock
@@ -142,24 +138,6 @@ class CniIpamTest(unittest.TestCase):
         ip6 = IPNetwork("ba:ad::be:ef/128")
         self.plugin.datastore_client.auto_assign_ips = MagicMock(spec=self.plugin._assign_address)
         self.plugin.datastore_client.auto_assign_ips.return_value = [], [ip6]
-
-        # Args
-        handle_id = "abcdef12345"
-
-        # Call
-        with assert_raises(CniError) as err:
-            self.plugin._assign_address(handle_id)
-        e = err.exception
-
-        # Assert
-        assert_equal(e.code, ERR_CODE_GENERIC)
-
-    @patch("ipam._exit_on_error", autospec=True)
-    def test_assign_address_no_ipv6(self, m_exit):
-        # Mock
-        ip4 = IPNetwork("1.2.3.4/32")
-        self.plugin.datastore_client.auto_assign_ips = MagicMock(spec=self.plugin._assign_address)
-        self.plugin.datastore_client.auto_assign_ips.return_value = [ip4], []
 
         # Args
         handle_id = "abcdef12345"


### PR DESCRIPTION
IPv6 isn't enabled by default on some hosts.

We should make it a user configurable option to turn it on.