### PR TITLE
Changes for v1alpha1 policy API

### DIFF
--- a/calico_cni/constants.py
+++ b/calico_cni/constants.py
@@ -17,7 +17,6 @@ import socket
 
 
 # System Specific Constants
-ORCHESTRATOR_ID = "cni"
 HOSTNAME = socket.gethostname()
 
 # Regex to parse CNI_ARGS.  Looks for key value pairs separated by an equals
@@ -61,6 +60,7 @@ ERR_CODE_GENERIC = 100   # Use this for all errors.
 
 # Policy modes.
 POLICY_MODE_ANNOTATIONS = "k8s-annotations"
+POLICY_MODE_DENY_INBOUND = "default-deny-inbound"
 
 # Logging Configuration
 LOG_DIR = "/var/log/calico/cni"

--- a/tests/fv/test_calico_cni.py
+++ b/tests/fv/test_calico_cni.py
@@ -166,6 +166,7 @@ class CniPluginFvTest(unittest.TestCase):
         """
         # Configure.
         self.cni_args = "K8S_POD_NAME=podname;K8S_POD_NAMESPACE=default"
+        workload_id = "default.podname"
         self.command = CNI_CMD_ADD
         ip4 = "10.0.0.1/32"
         ip6 = "0:0:0:0:0:ffff:a00:1"
@@ -195,7 +196,7 @@ class CniPluginFvTest(unittest.TestCase):
 
         # Assert an endpoint was created.
         self.client.create_endpoint.assert_called_once_with(ANY, 
-                "cni", self.container_id, [IPNetwork(ip4),IPNetwork(ip6)])
+                "k8s", workload_id, [IPNetwork(ip4), IPNetwork(ip6)])
 
         # Assert a profile was applied.
         self.client.append_profiles_to_endpoint.assert_called_once_with(
@@ -210,6 +211,7 @@ class CniPluginFvTest(unittest.TestCase):
         """
         # Configure.
         self.cni_args = "K8S_POD_NAME=podname;K8S_POD_NAMESPACE=defaultns"
+        workload_id = "defaultns.podname"
         self.command = CNI_CMD_ADD
         ip4 = "10.0.0.1/32"
         ip6 = "0:0:0:0:0:ffff:a00:1"
@@ -250,7 +252,7 @@ class CniPluginFvTest(unittest.TestCase):
 
         # Assert an endpoint was created.
         self.client.create_endpoint.assert_called_once_with(ANY, 
-                "cni", self.container_id, [IPNetwork(ip4), IPNetwork(ip6)])
+                "k8s", workload_id, [IPNetwork(ip4), IPNetwork(ip6)])
 
         # Assert profile was created.
         self.client.create_profile.assert_called_once_with(


### PR DESCRIPTION
This is semi backwards compatible with existing deployments.  Upgrading to this version will still be able to handle pods / endpoints created with previous versions of the plugin.  However, downgrade from this commit to an earlier commit will leak endpoints. 

- Uses the pod namespace and name for the workload_id in Kubernetes.
- Use 'k8s' as the orchestrator when running under Kubernetes rather than 'cni'
- Also introduces a new policy driver which denies all incoming traffic.

TODO:
- [x] Try to make this backwards compatible
- [x] Use the CNI network name for the calico profile (rather than `deny-inbound`)?
- [x] Re-name policy type "none" to something that makes sense.