### PR TITLE
Configuration for IPv4 vs IPv6 address assignment

### DIFF
--- a/calico.py
+++ b/calico.py
@@ -369,7 +369,8 @@ class CniPlugin(object):
         if self.ipam_type == "calico-ipam":
             _log.info("Using Calico IPAM")
             try:
-                response = IpamPlugin(env).execute()
+                response = IpamPlugin(env, 
+                                      self.network_config["ipam"]).execute()
                 code = 0
             except CniError as e:
                 # We hit a CNI error - return the appropriate CNI formatted

--- a/calico_cni/constants.py
+++ b/calico_cni/constants.py
@@ -48,6 +48,8 @@ K8S_POD_INFRA_CONTAINER_ID = "K8S_POD_INFRA_CONTAINER_ID"
 ETCD_AUTHORITY_KEY = "etcd_authority"
 LOG_LEVEL_KEY = "log_level"
 POLICY_KEY = "policy"
+ASSIGN_IPV4_KEY = "assign_ipv4"
+ASSIGN_IPV6_KEY = "assign_ipv6"
 
 # Constants for getting policy specific information 
 # from the policy dictionary in the network config file.

--- a/tests/fv/test_calico_cni.py
+++ b/tests/fv/test_calico_cni.py
@@ -128,7 +128,9 @@ class CniPluginFvTest(unittest.TestCase):
         # Configure.
         self.command = CNI_CMD_ADD
         ip4 = "10.0.0.1/32"
-        ipam_stdout = json.dumps({"ip4": {"ip": ip4}})
+        ip6 = "0:0:0:0:0:ffff:a00:1"
+        ipam_stdout = json.dumps({"ip4": {"ip": ip4}, 
+                                  "ip6": {"ip": ip6}})
         self.set_ipam_result(0, ipam_stdout, "")
 
         # Create plugin.
@@ -148,7 +150,7 @@ class CniPluginFvTest(unittest.TestCase):
 
         # Assert an endpoint was created.
         self.client.create_endpoint.assert_called_once_with(ANY, 
-                "cni", self.container_id, [IPNetwork(ip4)])
+                "cni", self.container_id, [IPNetwork(ip4), IPNetwork(ip6)])
 
         # Assert a profile was applied.
         self.client.append_profiles_to_endpoint.assert_called_once_with(
@@ -164,7 +166,9 @@ class CniPluginFvTest(unittest.TestCase):
         self.cni_args = "K8S_POD_NAME=podname;K8S_POD_NAMESPACE=default"
         self.command = CNI_CMD_ADD
         ip4 = "10.0.0.1/32"
-        ipam_stdout = json.dumps({"ip4": {"ip": ip4}})
+        ip6 = "0:0:0:0:0:ffff:a00:1"
+        ipam_stdout = json.dumps({"ip4": {"ip": ip4}, 
+                                  "ip6": {"ip": ip6}})
         self.set_ipam_result(0, ipam_stdout, "")
 
         # Set up docker client response.
@@ -189,7 +193,7 @@ class CniPluginFvTest(unittest.TestCase):
 
         # Assert an endpoint was created.
         self.client.create_endpoint.assert_called_once_with(ANY, 
-                "cni", self.container_id, [IPNetwork(ip4)])
+                "cni", self.container_id, [IPNetwork(ip4),IPNetwork(ip6)])
 
         # Assert a profile was applied.
         self.client.append_profiles_to_endpoint.assert_called_once_with(
@@ -206,7 +210,9 @@ class CniPluginFvTest(unittest.TestCase):
         self.cni_args = "K8S_POD_NAME=podname;K8S_POD_NAMESPACE=defaultns"
         self.command = CNI_CMD_ADD
         ip4 = "10.0.0.1/32"
-        ipam_stdout = json.dumps({"ip4": {"ip": ip4}})
+        ip6 = "0:0:0:0:0:ffff:a00:1"
+        ipam_stdout = json.dumps({"ip4": {"ip": ip4}, 
+                                  "ip6": {"ip": ip6}})
         self.set_ipam_result(0, ipam_stdout, "")
         self.policy = {"type": "k8s-annotations"}
 
@@ -242,7 +248,7 @@ class CniPluginFvTest(unittest.TestCase):
 
         # Assert an endpoint was created.
         self.client.create_endpoint.assert_called_once_with(ANY, 
-                "cni", self.container_id, [IPNetwork(ip4)])
+                "cni", self.container_id, [IPNetwork(ip4), IPNetwork(ip6)])
 
         # Assert profile was created.
         self.client.create_profile.assert_called_once_with(
@@ -433,7 +439,9 @@ class CniPluginFvTest(unittest.TestCase):
         # Configure.
         self.command = CNI_CMD_ADD
         ip4 = "10.0.0.1/32"
-        ipam_stdout = json.dumps({"ip4": {"ip": ip4}})
+        ip6 = "0:0:0:0:0:ffff:a00:1"
+        ipam_stdout = json.dumps({"ip4": {"ip": ip4}, 
+                                  "ip6": {"ip": ip6}})
         self.set_ipam_result(0, ipam_stdout, "")
 
         # Create plugin.
@@ -455,7 +463,7 @@ class CniPluginFvTest(unittest.TestCase):
 
         # Assert an endpoint was created.
         self.client.create_endpoint.assert_called_once_with(ANY, 
-                "cni", self.container_id, [IPNetwork(ip4)])
+                "cni", self.container_id, [IPNetwork(ip4), IPNetwork(ip6)])
 
         # Assert set_profile called by policy driver.
         self.client.append_profiles_to_endpoint.assert_called_once_with(
@@ -525,8 +533,10 @@ class CniPluginFvWithIpamTest(CniPluginFvTest):
         if stdout and not rc:
             # A successful add response.
             ip4 = json.loads(stdout)["ip4"]["ip"]
+            ip6 = json.loads(stdout)["ip6"]["ip"]
             ip4s = [ip4] if ip4 else []
-            self.m_ipam_plugin_client().auto_assign_ips.return_value = ip4s, None
+            ip6s = [ip6] if ip6 else []
+            self.m_ipam_plugin_client().auto_assign_ips.return_value = ip4s, ip6s
  
     def test_add_ipam_error(self):
         # Mock out auto_assign_ips to throw an error.

--- a/tests/fv/test_calico_cni.py
+++ b/tests/fv/test_calico_cni.py
@@ -89,7 +89,9 @@ class CniPluginFvTest(unittest.TestCase):
             "name": self.network_name, 
             "type": self.plugin_type,
             "ipam": {
-                "type": self.ipam_type
+                "type": self.ipam_type,
+                "assign_ipv6": "true",
+                "assign_ipv4": "true"
             },
             "policy": self.policy
         }

--- a/tests/unit/test_cni_plugin.py
+++ b/tests/unit/test_cni_plugin.py
@@ -387,7 +387,7 @@ class CniPluginTest(unittest.TestCase):
         ip6 = "0:0:0:0:0:ffff:a00:1"
         env = {}
         out = json.dumps({"ip4": {"ip": ip4}, "ip6": {"ip": ip6}})
-        m_ipam_plugin(env).execute.return_value = out
+        m_ipam_plugin(env, self.network_config).execute.return_value = out
 
         # Set IPAM type.
         self.plugin.ipam_type = "calico-ipam"
@@ -409,7 +409,7 @@ class CniPluginTest(unittest.TestCase):
         # Mock out return values.
         env = {}
         err = CniError(150, "message", "details")
-        m_ipam_plugin(env).execute.side_effect = err 
+        m_ipam_plugin(env, self.network_config).execute.side_effect = err 
 
         # Set IPAM type.
         self.plugin.ipam_type = "calico-ipam"

--- a/tests/unit/test_ipam.py
+++ b/tests/unit/test_ipam.py
@@ -40,10 +40,8 @@ class CniIpamTest(unittest.TestCase):
             "type": "calico",
             "ipam": {
                 "type": "calico-ipam",
-                "subnet": "10.22.0.0/16",
-                "routes": [{"dst": "0.0.0.0/0"}],
-                "range-start": "",
-                "range-end": ""
+                ASSIGN_IPV4_KEY: "true",
+                ASSIGN_IPV6_KEY: "true"
             }
         }
         self.env = {
@@ -56,7 +54,7 @@ class CniIpamTest(unittest.TestCase):
         }
 
         # Create the CniPlugin to test.
-        self.plugin = IpamPlugin(self.env)
+        self.plugin = IpamPlugin(self.env, self.network_config["ipam"])
 
         # Mock out the datastore client.
         self.m_datastore_client = MagicMock(spec=IPAMClient)
@@ -222,8 +220,8 @@ class CniIpamTest(unittest.TestCase):
         main()
 
         # Assert
-        m_plugin.assert_called_once_with(self.env)
-        m_plugin(self.env).execute.assert_called_once_with()
+        m_plugin.assert_called_once_with(self.env, self.network_config["ipam"])
+        m_plugin(self.env, self.network_config["ipam"]).execute.assert_called_once_with()
 
     @patch("ipam.os", autospec=True)
     @patch("ipam.sys", autospec=True)
@@ -235,7 +233,7 @@ class CniIpamTest(unittest.TestCase):
         m_os.environ = self.env
         m_sys.stdin.readlines.return_value = json.dumps(self.network_config)
         m_plugin.reset_mock()
-        m_plugin(self.env).execute.side_effect = CniError(50, "Message", "Details") 
+        m_plugin(self.env, self.network_config["ipam"]).execute.side_effect = CniError(50, "Message", "Details") 
 
         # Call
         main()
@@ -253,7 +251,7 @@ class CniIpamTest(unittest.TestCase):
         m_os.environ = self.env
         m_sys.stdin.readlines.return_value = json.dumps(self.network_config)
         m_plugin.reset_mock()
-        m_plugin(self.env).execute.side_effect = Exception
+        m_plugin(self.env, self.network_config["ipam"]).execute.side_effect = Exception
 
         # Call
         main()

--- a/tests/unit/test_ipam.py
+++ b/tests/unit/test_ipam.py
@@ -67,14 +67,16 @@ class CniIpamTest(unittest.TestCase):
         # Mock
         self.plugin.command = CNI_CMD_ADD
         ip4 = IPNetwork("1.2.3.4/32")
+        ip6 = IPNetwork("ba:ad::be:ef/128")
         self.plugin._assign_address = MagicMock(spec=self.plugin._assign_address)
-        self.plugin._assign_address.return_value = ip4, None
+        self.plugin._assign_address.return_value = ip4, ip6
 
         # Call 
         ret = self.plugin.execute()
 
         # Assert
-        expected = json.dumps({"ip4": {"ip": "1.2.3.4/32"}})
+        expected = json.dumps({"ip4": {"ip": "1.2.3.4/32"}, 
+                               "ip6": {"ip": "ba:ad::be:ef/128"}})
         assert_equal(ret, expected)
 
     @patch('sys.stdout', new_callable=StringIO)
@@ -106,17 +108,19 @@ class CniIpamTest(unittest.TestCase):
     def test_assign_address_mainline(self):
         # Mock
         ip4 = IPNetwork("1.2.3.4/32")
+        ip6 = IPNetwork("ba:ad::be:ef/128")
         self.plugin.datastore_client.auto_assign_ips = MagicMock(spec=self.plugin._assign_address)
-        self.plugin.datastore_client.auto_assign_ips.return_value = [ip4], []
+        self.plugin.datastore_client.auto_assign_ips.return_value = [ip4], [ip6]
 
         # Args
         handle_id = "abcdef12345"
 
         # Call
-        ret_ip4, _ = self.plugin._assign_address(handle_id)
+        ret_ip4, ret_ip6 = self.plugin._assign_address(handle_id)
 
         # Assert
         assert_equal(ip4, ret_ip4)
+        assert_equal(ip6, ret_ip6)
 
     def test_assign_address_runtime_err(self):
         # Mock
@@ -138,6 +142,24 @@ class CniIpamTest(unittest.TestCase):
         ip6 = IPNetwork("ba:ad::be:ef/128")
         self.plugin.datastore_client.auto_assign_ips = MagicMock(spec=self.plugin._assign_address)
         self.plugin.datastore_client.auto_assign_ips.return_value = [], [ip6]
+
+        # Args
+        handle_id = "abcdef12345"
+
+        # Call
+        with assert_raises(CniError) as err:
+            self.plugin._assign_address(handle_id)
+        e = err.exception
+
+        # Assert
+        assert_equal(e.code, ERR_CODE_GENERIC)
+
+    @patch("ipam._exit_on_error", autospec=True)
+    def test_assign_address_no_ipv6(self, m_exit):
+        # Mock
+        ip4 = IPNetwork("1.2.3.4/32")
+        self.plugin.datastore_client.auto_assign_ips = MagicMock(spec=self.plugin._assign_address)
+        self.plugin.datastore_client.auto_assign_ips.return_value = [ip4], []
 
         # Args
         handle_id = "abcdef12345"


### PR DESCRIPTION
@tomdee Turned out to be a bit more than 3 lines of code..

Allows the following:
```
{
  "type": "calico-ipam",
  "assign_ipv4": "true",
  "assign_ipv6": "true"
}

```