### PR TITLE
Add version flag

### DIFF
--- a/calico_cni/__init__.py
+++ b/calico_cni/__init__.py
@@ -1,0 +1,4 @@
+# Auto-generated contents.  Do not manually edit!
+__version__ = 'v1.0.2-9-g0e484fa'
+__commit__ = '0e484fae8b0d0a60f7517b98dfbe9691bb583ceb'
+__branch__ = 'version-flag'


### PR DESCRIPTION
Prints the version of the plugin.

Fixes #56 

Example:
```
gulfstream@gulfstream:~/repos/calico-cni$ ./dist/calico -v
{
  "Commit": "582ff4ed9c2c3552ee82e417f35c8aab7ef00127",
  "Version": "v1.0.2-dev",
  "Branch": "version-flag"
}
```

For now, population of the version tag will be done manually on release.