### PR TITLE
Fix typo in substitution variable

### DIFF
--- a/samples/kubernetes/cloud-config/node-config-template.yaml
+++ b/samples/kubernetes/cloud-config/node-config-template.yaml
@@ -153,7 +153,7 @@ write_files:
           command:
           - /hyperkube
           - proxy
-          - --master=https://<KUBRNETES_MASTER>:443
+          - --master=https://<KUBERNETES_MASTER>:443
           - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
           - --proxy-mode=iptables
           securityContext:


### PR DESCRIPTION
Fix typo which would cause those using search-and-replace to have a malformed cloud-config template