### PR TITLE
"no handlers found for calico_cni", when conf file contains tab characters 

### DIFF
--- a/calico.py
+++ b/calico.py
@@ -669,7 +669,7 @@ def main():
     # problems when loading values into os.environ.
     # Rather than try to encode them as strings, just use the yaml library.
     # For more details see http://stackoverflow.com/questions/956867/how-to-get-string-objects-instead-of-unicode-ones-from-json-in-python
-    config_raw = ''.join(sys.stdin.readlines()).replace('\n', '')
+    config_raw = ''.join(sys.stdin.readlines()).replace('\n', '').replace('\t','')
     network_config = yaml.safe_load(config_raw)
 
     # Get the log level from the config file, default to INFO.

--- a/calico_cni/util.py
+++ b/calico_cni/util.py
@@ -94,7 +94,7 @@ def print_cni_error(code, message, details=None):
         "msg": message,
         "details": details
     }
-    _log.error("CNI Error:\n%s", json.dumps(error_response, indent=2))
+    _log.exception("CNI Error:\n%s", json.dumps(error_response, indent=2))
     print(json.dumps(error_response))
 
 


### PR DESCRIPTION
correction of an error happenig when config file /etc/cna/net.d/10-calico.conf contains tab characters, and printing full stacktrace in log file in order to make easier to figure out where errors happen