### PR TITLE
kubeconfig, podCidr support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dist/calico: $(SRCFILES)
 	docker run  --rm \
 	-v `pwd`:/code \
 	calico/build:$(BUILD_VERSION) \
-	pyinstaller calico.py -ayF
+	/bin/sh -c "pip install pykube && pyinstaller calico.py -ayF"
 
 # Makes the IPAM plugin.
 dist/calico-ipam: $(SRCFILES) 

--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,13 @@ deploy-rkt: dist/calicoctl
 ut: update-version
 	docker run --rm -v `pwd`:/code \
 	calico/test \
-	nosetests tests/unit -c nose.cfg
+	sh -c "pip install pykube && nosetests tests/unit -c nose.cfg"
 
 # Run the fv tests.
 fv: update-version
 	docker run --rm -v `pwd`:/code \
 	calico/test \
-	nosetests tests/fv -c nose.cfg
+	sh -c "pip install pykube && nosetests tests/fv -c nose.cfg"
 
 # Makes tests on Circle CI.
 test-circle: update-version dist/calico dist/calico-ipam
@@ -63,7 +63,8 @@ test-circle: update-version dist/calico dist/calico-ipam
 	-v $(CIRCLE_TEST_REPORTS):/circle_output \
 	-e COVERALLS_REPO_TOKEN=$(COVERALLS_REPO_TOKEN) \
 	calico/test sh -c \
-	'nosetests tests -c nose.cfg \
+	'pip install pykube && \
+	nosetests tests -c nose.cfg \
 	--with-xunit --xunit-file=/circle_output/output.xml; RC=$$?;\
 	[[ ! -z "$$COVERALLS_REPO_TOKEN" ]] && coveralls || true; exit $$RC'
 

--- a/calico.py
+++ b/calico.py
@@ -35,7 +35,7 @@ from calico_cni.util import (configure_logging, parse_cni_args, print_cni_error,
 
 from calico_cni.container_engines import get_container_engine
 from calico_cni.constants import *
-from calico_cni.policy_drivers import ApplyProfileError, get_policy_driver
+from calico_cni.policy_drivers import PolicyException, get_policy_driver
 from ipam import IpamPlugin
 
 # Logging configuration.
@@ -259,7 +259,7 @@ class CniPlugin(object):
         # Provision / apply profile on the created endpoint.
         try:
             self.policy_driver.apply_profile(endpoint)
-        except ApplyProfileError as e:
+        except PolicyException as e:
             _log.error("Failed to apply profile to endpoint %s",
                        endpoint.name)
             self._remove_veth(endpoint)
@@ -297,7 +297,7 @@ class CniPlugin(object):
         # Apply a new profile to this endpoint.
         try:
             self.policy_driver.apply_profile(endpoint)
-        except ApplyProfileError as e:
+        except PolicyException as e:
             # Hit an exception applying the profile.  We haven't configured
             # anything, so we don't need to clean anything up.  Just exit.
             _log.error("Failed to apply profile to endpoint %s",

--- a/calico.py
+++ b/calico.py
@@ -32,7 +32,6 @@ from pycalico.datastore_errors import MultipleEndpointsMatch
 from pykube.config import KubeConfig
 from pykube.http import HTTPClient
 from pykube.objects import Node
-from pykube.query import Query
 
 from calico_cni import __version__, __commit__, __branch__
 from calico_cni.util import (configure_logging, parse_cni_args, print_cni_error,
@@ -456,8 +455,8 @@ class CniPlugin(object):
             if self.network_config["ipam"].get("subnet") == "usePodCidr":
                 if not self.running_under_k8s:
                     print_cni_error(ERR_CODE_GENERIC, "Invalid network config",
-                            "Must be running under Kubernetes to use \
-                                    'subnet: usePodCidr'")
+                            "Must be running under Kubernetes to use 'subnet: usePodCidr'")
+                    sys.exit(ERR_CODE_GENERIC)
                 _log.info("Using Kubernetes podCIDR for node: %s", self.k8s_node_name)
                 pod_cidr = self._get_kubernetes_pod_cidr()
                 self.network_config["ipam"]["subnet"] = str(pod_cidr)
@@ -493,8 +492,8 @@ class CniPlugin(object):
             api = HTTPClient(KubeConfig.from_file(self.kubeconfig_path))
             node = None
             for n in Node.objects(api):
+                _log.debug("Checking node: %s", n.obj["metadata"]["name"])
                 if n.obj["metadata"]["name"] == self.k8s_node_name:
-                    _log.debug("Checking node: %s", n.obj["metadata"]["name"])
                     node = n
                     break
             if not node:

--- a/calico_cni/constants.py
+++ b/calico_cni/constants.py
@@ -15,8 +15,11 @@
 import re
 import socket
 
+# The hostname of the current node.
+HOSTNAME = socket.gethostname()
+
 # Regex to parse CNI_ARGS.  Looks for key value pairs separated by an equals
-# sign and followed either the end of the string, or a colon (indicating 
+# sign and followed either the end of the string, or a colon (indicating
 # that there is another CNI_ARG key/value pair.
 CNI_ARGS_RE = re.compile("([a-zA-Z0-9/\.\-\_ ]+)=([a-zA-Z0-9/\.\-\_ ]+)(?:;|$)")
 
@@ -54,7 +57,7 @@ POLICY_KEY = "policy"
 ASSIGN_IPV4_KEY = "assign_ipv4"
 ASSIGN_IPV6_KEY = "assign_ipv6"
 
-# Constants for getting policy specific information 
+# Constants for getting policy specific information
 # from the policy dictionary in the network config file.
 API_ROOT_KEY = "k8s_api_root"
 AUTH_TOKEN_KEY = "k8s_auth_token"

--- a/calico_cni/constants.py
+++ b/calico_cni/constants.py
@@ -15,9 +15,6 @@
 import re
 import socket
 
-# The hostname of the current node.
-HOSTNAME = socket.gethostname()
-
 # Regex to parse CNI_ARGS.  Looks for key value pairs separated by an equals
 # sign and followed either the end of the string, or a colon (indicating
 # that there is another CNI_ARG key/value pair.

--- a/calico_cni/policy_drivers.py
+++ b/calico_cni/policy_drivers.py
@@ -252,7 +252,7 @@ class KubernetesAnnotationDriver(DefaultPolicyDriver):
     def _get_api_pod(self):
         """Get the pod resource from the API.
 
-        :return: JSON object containing the pod spec
+        :return: Dictionary representation of Pod from k8s API.
         """
         # If kubeconfig was specified, use the pykube library.
         if self.kubeconfig_path:
@@ -260,7 +260,7 @@ class KubernetesAnnotationDriver(DefaultPolicyDriver):
             try:
                 api = HTTPClient(KubeConfig.from_file(self.kubeconfig_path))
                 pod = Query(api, Pod, self.namespace).get_by_name(self.pod_name)
-                _log.info("Found pod: %s: ", pod.obj)
+                _log.debug("Found pod: %s: ", pod.obj)
             except Exception as e:
                 raise PolicyException("Error querying Kubernetes API",
                                       details=str(e.message))
@@ -400,6 +400,7 @@ def get_policy_driver(cni_plugin):
     policy_config = cni_plugin.network_config.get(POLICY_KEY, {})
     network_name = cni_plugin.network_config["name"]
     policy_type = policy_config.get("type")
+    k8s_config = cni_plugin.network_config.get("kubernetes", {})
     supported_policy_types = [None,
                               POLICY_MODE_KUBERNETES,
                               POLICY_MODE_KUBERNETES_ANNOTATIONS]
@@ -423,7 +424,7 @@ def get_policy_driver(cni_plugin):
             client_key = policy_config.get(K8S_CLIENT_KEY_VAR)
             certificate_authority = policy_config.get(
                 K8S_CERTIFICATE_AUTHORITY_VAR)
-            kubeconfig_path = policy_config.get("kubeconfig")
+            kubeconfig_path = k8s_config.get("kubeconfig")
 
             if (client_key and not os.path.isfile(client_key)) or \
                (client_certificate and not os.path.isfile(client_certificate)) or \

--- a/configuration.md
+++ b/configuration.md
@@ -66,6 +66,7 @@ The CNI plugin may need to authenticate with the Kubernetes API server. The foll
 * `k8s_certificate_authority`
 	* Verifying the API certificate against a CA only works if connecting to the API server using a hostname.
 * `kubeconfig`
+	* Path to a Kubernetes `kubeconfig` file.
 
 
 [![Analytics](https://calico-ga-beacon.appspot.com/UA-52125893-3/calico-cni/configuration.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/configuration.md
+++ b/configuration.md
@@ -44,6 +44,8 @@ When using Calico IPAM, the following flags determine what IP addresses should b
 
 A specific IP address can be chosen by using [`CNI_ARGS`](https://github.com/appc/cni/blob/master/SPEC.md#parameters) and setting `IP` to the desired value.
 
+When using the CNI `host-local` IPAM plugin, a special value `usePodCidr` is allowed for the subnet field.  This tells the plugin to determine the subnet to use from the Kubernetes API based on the Node.podCIDR field.  This is currently only supported when using `kubeconfig` for accessing the API. 
+
 ## Kubernetes specific
 
 When using the Calico CNI plugin with Kubernetes, an additional config block can be specified to control how network policy is configured. The required config block is `policy`. See the [Calico Kubernetes documentation](https://github.com/projectcalico/calico-containers/tree/master/docs/cni/kubernetes) for more information.
@@ -63,6 +65,7 @@ The CNI plugin may need to authenticate with the Kubernetes API server. The foll
 * `k8s_client_key`
 * `k8s_certificate_authority`
 	* Verifying the API certificate against a CA only works if connecting to the API server using a hostname.
+* `kubeconfig`
 
 
 [![Analytics](https://calico-ga-beacon.appspot.com/UA-52125893-3/calico-cni/configuration.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/tests/unit/test_cni_plugin.py
+++ b/tests/unit/test_cni_plugin.py
@@ -26,7 +26,7 @@ from subprocess32 import CalledProcessError, Popen, PIPE
 
 from calico_cni.constants import *
 from calico_cni.policy_drivers import (DefaultPolicyDriver, ApplyProfileError)
-from calico_cni.container_engines import DockerEngine 
+from calico_cni.container_engines import DockerEngine
 from calico_cni.util import CniError
 from calico import main, CniPlugin
 
@@ -58,7 +58,7 @@ class CniPluginTest(unittest.TestCase):
                 CNI_CONTAINERID_ENV: self.container_id,
                 CNI_IFNAME_ENV: "eth0",
                 CNI_ARGS_ENV: "IP=1.2.3.4",
-                CNI_COMMAND_ENV: CNI_CMD_ADD, 
+                CNI_COMMAND_ENV: CNI_CMD_ADD,
                 CNI_PATH_ENV: "/usr/bin/rkt/",
                 CNI_NETNS_ENV: "netns",
         }
@@ -66,7 +66,7 @@ class CniPluginTest(unittest.TestCase):
         # Create the CniPlugin to test.
         self.plugin = CniPlugin(self.network_config, self.env)
 
-        # Mock out policy driver. 
+        # Mock out policy driver.
         self.plugin.policy_driver = MagicMock(spec=DefaultPolicyDriver)
 
         # Mock out the datastore client.
@@ -98,7 +98,7 @@ class CniPluginTest(unittest.TestCase):
         self.plugin.delete.assert_called_once_with()
 
     @patch("calico.json", autospec=True)
-    def test_add_mainline(self, m_json): 
+    def test_add_mainline(self, m_json):
         # Mock out _assign_ips.
         ip4 = IPNetwork("10.0.0.1/32")
         ip6 = IPNetwork("0:0:0:0:0:ffff:a00:1/128")
@@ -112,7 +112,7 @@ class CniPluginTest(unittest.TestCase):
         self.plugin._create_endpoint = MagicMock(spec=self.plugin._create_endpoint)
         self.plugin._create_endpoint.return_value = endpoint
 
-        # Mock out _provision_veth. 
+        # Mock out _provision_veth.
         self.plugin._provision_veth = MagicMock(spec=self.plugin._provision_veth)
         self.plugin._provision_veth.return_value = endpoint
 
@@ -131,7 +131,7 @@ class CniPluginTest(unittest.TestCase):
         m_json.dumps.assert_called_once_with(ipam_response)
 
     @patch("calico.json", autospec=True)
-    def test_add_host_networking(self, m_json): 
+    def test_add_host_networking(self, m_json):
         # Mock out.
         self.plugin.container_engine.uses_host_networking = MagicMock(return_value=True)
 
@@ -139,9 +139,9 @@ class CniPluginTest(unittest.TestCase):
         assert_raises(SystemExit, self.plugin.add)
 
     @patch("calico.json", autospec=True)
-    def test_add_exists_new_network(self, m_json): 
+    def test_add_exists_new_network(self, m_json):
         """
-        Test add when the endpoint already exists, adding to a new 
+        Test add when the endpoint already exists, adding to a new
         network.
         """
         # Mock out methods that should not be called.
@@ -172,7 +172,7 @@ class CniPluginTest(unittest.TestCase):
         m_json.dumps.assert_called_once_with(expected)
 
     @patch("calico.json", autospec=True)
-    def test_add_profile_error(self, m_json): 
+    def test_add_profile_error(self, m_json):
         """
         Test add when the endpoint does not exist, error applying profile.
         """
@@ -197,26 +197,26 @@ class CniPluginTest(unittest.TestCase):
         self.plugin._create_endpoint = MagicMock(spec=self.plugin._create_endpoint)
         self.plugin._create_endpoint.return_value = endpoint
 
-        # Mock out _provision_veth. 
+        # Mock out _provision_veth.
         self.plugin._provision_veth = MagicMock(spec=self.plugin._provision_veth)
         self.plugin._provision_veth.return_value = endpoint
 
         # Mock out apply_profile to throw error.
         msg = "Apply Profile Error Message"
         error = ApplyProfileError(msg)
-        self.plugin.policy_driver.apply_profile.side_effect = error  
+        self.plugin.policy_driver.apply_profile.side_effect = error
 
         # Mock out _get_endpoint - endpoint exists.
         self.plugin._get_endpoint = MagicMock(spec=self.plugin._get_endpoint)
-        self.plugin._get_endpoint.return_value = None 
+        self.plugin._get_endpoint.return_value = None
 
         # Call method.
         assert_raises(SystemExit, self.plugin.add)
 
     @patch("calico.json", autospec=True)
-    def test_add_exists_new_network_profile_error(self, m_json): 
+    def test_add_exists_new_network_profile_error(self, m_json):
         """
-        Test add when the endpoint already exists, adding to a new 
+        Test add when the endpoint already exists, adding to a new
         network, error applying profile.
         """
         # Mock out apply_profile to throw error.
@@ -236,10 +236,10 @@ class CniPluginTest(unittest.TestCase):
         assert_raises(SystemExit, self.plugin.add)
 
     @patch("calico.json", autospec=True)
-    def test_add_exists_no_ips(self, m_json): 
+    def test_add_exists_no_ips(self, m_json):
         """
         Tests add to new network when endpoint exists,
-        no IP addresses are assigned. 
+        no IP addresses are assigned.
         """
         # Mock out _get_endpoint - endpoint exists.
         endpoint = MagicMock(spec=Endpoint)
@@ -289,7 +289,7 @@ class CniPluginTest(unittest.TestCase):
 
         # Mock out _get_endpoint.
         self.plugin._get_endpoint = MagicMock(spec=self.plugin._get_endpoint)
-        self.plugin._get_endpoint.return_value = None  
+        self.plugin._get_endpoint.return_value = None
 
         # Call delete()
         assert_raises(SystemExit, self.plugin.delete)
@@ -321,7 +321,7 @@ class CniPluginTest(unittest.TestCase):
     def test_assign_ip_invalid_response(self):
         # Mock _call_ipam_plugin.
         rc = 1
-        ipam_result = "Invalid json" 
+        ipam_result = "Invalid json"
         self.plugin._call_ipam_plugin = MagicMock(spec=self.plugin._call_ipam_plugin)
         self.plugin._call_ipam_plugin.return_value = rc, ipam_result
         env = {CNI_COMMAND_ENV: CNI_CMD_ADD}
@@ -337,8 +337,8 @@ class CniPluginTest(unittest.TestCase):
         rc = ERR_CODE_GENERIC
         msg = "Message"
         details = "Details"
-        ipam_result = json.dumps({"code": rc, 
-                                  "msg": msg, 
+        ipam_result = json.dumps({"code": rc,
+                                  "msg": msg,
                                   "details": details})
         self.plugin._call_ipam_plugin = MagicMock(spec=self.plugin._call_ipam_plugin)
         self.plugin._call_ipam_plugin.return_value = rc, ipam_result
@@ -403,6 +403,7 @@ class CniPluginTest(unittest.TestCase):
         # Call _release_ip.
         self.plugin._release_ip(env)
 
+
     @patch("calico.IpamPlugin", autospec=True)
     def test_call_ipam_plugin_calico_mainline(self, m_ipam_plugin):
         # Mock _find_ipam_plugin.
@@ -437,7 +438,7 @@ class CniPluginTest(unittest.TestCase):
         # Mock out return values.
         env = {}
         err = CniError(150, "message", "details")
-        m_ipam_plugin(env, self.network_config).execute.side_effect = err 
+        m_ipam_plugin(env, self.network_config).execute.side_effect = err
 
         # Set IPAM type.
         self.plugin.ipam_type = "calico-ipam"
@@ -449,6 +450,31 @@ class CniPluginTest(unittest.TestCase):
         expected = '{"msg": "message", "code": 150, "details": "details"}'
         assert_equal(rc, 150)
         assert_equal(result, expected)
+
+    @patch("calico.CniPlugin._call_binary_ipam_plugin", autospec=True)
+    def test_call_ipam_plugin_host_local_podcidr(self, m_call_bin):
+        # Mock _find_ipam_plugin.
+        plugin_path = "/opt/bin/cni/host-local"
+        self.plugin._find_ipam_plugin = MagicMock(spec=self.plugin._find_ipam_plugin)
+        self.plugin._find_ipam_plugin.return_value = plugin_path
+
+        # Mock out return values.
+        ip4 = "10.0.0.1/32"
+        ip6 = "0:0:0:0:0:ffff:a00:1"
+        env = {}
+        out = json.dumps({"ip4": {"ip": ip4}, "ip6": {"ip": ip6}})
+        m_call_bin.return_value = 0, out
+
+        # Set IPAM type.
+        self.plugin.ipam_type = "host-local"
+        self.plugin.network_config["ipam"]["subnet"] = "usePodCidr"
+        self.plugin.network_config["kubernetes"] = {"kubeconfig": "/path/to/kubeconfig"}
+
+        # This is not a valid configuration when not running under Kubernetes.
+        with assert_raises(SystemExit) as err:
+            self.plugin._call_ipam_plugin(env)
+        e = err.exception
+        assert_equal(e.code, ERR_CODE_GENERIC)
 
     @patch("calico.Popen", autospec=True)
     def test_call_ipam_plugin_binary_mainline(self, m_popen):
@@ -476,9 +502,9 @@ class CniPluginTest(unittest.TestCase):
 
         # Assert.
         assert_equal(rc, 0)
-        m_popen.assert_called_once_with(plugin_path, 
-                                        stdin=PIPE, 
-                                        stdout=PIPE, 
+        m_popen.assert_called_once_with(plugin_path,
+                                        stdin=PIPE,
+                                        stdout=PIPE,
                                         stderr=PIPE,
                                         env=env)
         m_proc.communicate.assert_called_once_with(json.dumps(self.plugin.network_config))
@@ -491,10 +517,10 @@ class CniPluginTest(unittest.TestCase):
         """
         # Mock _find_ipam_plugin.
         self.plugin._find_ipam_plugin = MagicMock(spec=self.plugin._find_ipam_plugin)
-        self.plugin._find_ipam_plugin.return_value = None 
+        self.plugin._find_ipam_plugin.return_value = None
         env = {}
 
-        # Set IPAM type. 
+        # Set IPAM type.
         self.plugin.ipam_type = "not-calico"
 
         # Call method.
@@ -514,7 +540,7 @@ class CniPluginTest(unittest.TestCase):
         ep = self.plugin._create_endpoint(ip_list)
 
         # Assert.
-        self.plugin._client.create_endpoint.assert_called_once_with(ANY, 
+        self.plugin._client.create_endpoint.assert_called_once_with(ANY,
                 self.expected_orch_id, self.expected_workload_id, ip_list)
         assert_equal(ep, endpoint)
 
@@ -541,14 +567,14 @@ class CniPluginTest(unittest.TestCase):
 
         # Assert
         self.plugin._client.remove_workload.assert_called_once_with(hostname=ANY,
-                workload_id=self.expected_workload_id, 
+                workload_id=self.expected_workload_id,
                 orchestrator_id=self.expected_orch_id)
 
     def test_remove_workload_does_not_exist(self):
         """
         Make sure we handle this case gracefully - no exception raised.
         """
-        self.plugin._client.remove_workload.side_effect = KeyError 
+        self.plugin._client.remove_workload.side_effect = KeyError
         self.plugin._remove_workload()
 
     @patch("calico.os", autospec=True)
@@ -631,8 +657,8 @@ class CniPluginTest(unittest.TestCase):
 
         # Assert
         assert_equal(ep, endpoint)
-        self.plugin._client.get_endpoint.assert_called_once_with(hostname=ANY, 
-                orchestrator_id=self.expected_orch_id, 
+        self.plugin._client.get_endpoint.assert_called_once_with(hostname=ANY,
+                orchestrator_id=self.expected_orch_id,
                 workload_id=self.expected_workload_id)
 
     def test_get_endpoint_no_endpoint(self):
@@ -644,15 +670,15 @@ class CniPluginTest(unittest.TestCase):
 
         # Assert
         assert_equal(ep, None)
-        calls = [call(hostname=ANY, orchestrator_id=self.expected_orch_id, 
+        calls = [call(hostname=ANY, orchestrator_id=self.expected_orch_id,
                       workload_id=self.expected_workload_id),
-                 call(hostname=ANY, orchestrator_id="cni", 
+                 call(hostname=ANY, orchestrator_id="cni",
                       workload_id=self.container_id)]
         self.plugin._client.get_endpoint.assert_has_calls(calls)
 
     def test_get_endpoint_multiple_endpoints(self):
         # Mock
-        self.plugin._client.get_endpoint.side_effect = MultipleEndpointsMatch 
+        self.plugin._client.get_endpoint.side_effect = MultipleEndpointsMatch
 
         # Call
         with assert_raises(SystemExit) as err:
@@ -661,8 +687,8 @@ class CniPluginTest(unittest.TestCase):
         assert_equal(e.code, ERR_CODE_GENERIC)
 
         # Assert
-        self.plugin._client.get_endpoint.assert_called_once_with(hostname=ANY, 
-                orchestrator_id=self.expected_orch_id, 
+        self.plugin._client.get_endpoint.assert_called_once_with(hostname=ANY,
+                orchestrator_id=self.expected_orch_id,
                 workload_id=self.expected_workload_id)
 
     def test_remove_stale_endpoint(self):
@@ -757,7 +783,7 @@ class CniPluginTest(unittest.TestCase):
 
 class CniPluginKubernetesTest(CniPluginTest):
     """
-    Test class for CniPlugin class when running under Kubernetes. Runs all 
+    Test class for CniPlugin class when running under Kubernetes. Runs all
     of the CniPluginTest cases with Kubernetes specific parameters specified.
     """
     def setUp(self):
@@ -772,7 +798,7 @@ class CniPluginKubernetesTest(CniPluginTest):
                 CNI_CONTAINERID_ENV: self.container_id,
                 CNI_IFNAME_ENV: "eth0",
                 CNI_ARGS_ENV: "K8S_POD_NAME=testpod;K8S_POD_NAMESPACE=k8sns",
-                CNI_COMMAND_ENV: CNI_CMD_ADD, 
+                CNI_COMMAND_ENV: CNI_CMD_ADD,
                 CNI_PATH_ENV: "/opt/cni/bin",
                 CNI_NETNS_ENV: "netns",
         }
@@ -781,10 +807,10 @@ class CniPluginKubernetesTest(CniPluginTest):
         # config.
         self.plugin = CniPlugin(self.network_config, self.env)
 
-        # Mock out policy driver. 
+        # Mock out policy driver.
         self.plugin.policy_driver = MagicMock(spec=DefaultPolicyDriver)
 
-        # Mock out container engine 
+        # Mock out container engine
         self.plugin.container_engine = MagicMock(spec=DockerEngine)
         self.plugin.container_engine.uses_host_networking.return_value = False
 
@@ -794,11 +820,11 @@ class CniPluginKubernetesTest(CniPluginTest):
 
         # Set the expected values.
         self.expected_orch_id = "k8s"
-        self.expected_workload_id = "k8sns.testpod" 
+        self.expected_workload_id = "k8sns.testpod"
 
     @patch("calico.json", autospec=True)
     @patch("calico.IpamPlugin", autospec=True)
-    def test_add_exists_no_ips(self, m_ipam, m_json): 
+    def test_add_exists_no_ips(self, m_ipam, m_json):
         """
         In k8s, if an endpoint exists already, we must clean it up.
         """
@@ -830,17 +856,110 @@ class CniPluginKubernetesTest(CniPluginTest):
 
         # Assert we clean up policy.
         self.plugin.policy_driver.remove_profile.assert_called_once_with()
-        
+
         # Assert we add a new endpoint.
         self.plugin._add_new_endpoint.assert_called_once_with()
 
     @patch("calico.json", autospec=True)
-    def test_add_exists_new_network(self, m_json): 
+    def test_add_exists_new_network(self, m_json):
         """
         In k8s, we never add a new network to an existing endpoint.
         """
         pass
 
     @patch("calico.json", autospec=True)
-    def test_add_exists_new_network_profile_error(self, m_json): 
+    def test_add_exists_new_network_profile_error(self, m_json):
         pass
+
+    @patch("calico.CniPlugin._call_binary_ipam_plugin", autospec=True)
+    @patch("calico.HTTPClient", autospec=True)
+    @patch("calico.Node", autospec=True)
+    @patch("calico.KubeConfig", autospec=True)
+    def test_call_ipam_plugin_host_local_podcidr(self, m_kcfg, m_node, m_http, m_call_bin):
+        # Mock _find_ipam_plugin.
+        plugin_path = "/opt/bin/cni/host-local"
+        self.plugin._find_ipam_plugin = MagicMock(spec=self.plugin._find_ipam_plugin)
+        self.plugin._find_ipam_plugin.return_value = plugin_path
+
+        # Mock out return values.
+        ip4 = "10.0.0.1/32"
+        ip6 = "0:0:0:0:0:ffff:a00:1"
+        env = {}
+        out = json.dumps({"ip4": {"ip": ip4}, "ip6": {"ip": ip6}})
+        m_call_bin.return_value = 0, out
+
+        # Set IPAM type.
+        self.plugin.ipam_type = "host-local"
+        self.plugin.network_config["ipam"]["subnet"] = "usePodCidr"
+        self.plugin.kubeconfig_path = "/path/to/kubeconfig"
+        self.plugin.k8s_node_name = "nodename"
+
+        # Setup response.
+        node = MagicMock(obj={"metadata": {"name": "nodename"}, "spec":{"podCIDR": "1.2.3.4"}})
+        nodes = [node]
+        m_node.objects.return_value = nodes
+
+        # Call _call_ipam_plugin.
+        rc, result = self.plugin._call_ipam_plugin(env)
+
+        # Assert.
+        assert_equal(rc, 0)
+        assert_equal(result, out)
+
+
+    @patch("calico.CniPlugin._call_binary_ipam_plugin", autospec=True)
+    @patch("calico.HTTPClient", autospec=True)
+    @patch("calico.Node", autospec=True)
+    @patch("calico.KubeConfig", autospec=True)
+    def test_call_ipam_plugin_host_local_podcidr_no_podcidr(self, m_kcfg, m_node, m_http, m_call_bin):
+        # Mock _find_ipam_plugin.
+        plugin_path = "/opt/bin/cni/host-local"
+        self.plugin._find_ipam_plugin = MagicMock(spec=self.plugin._find_ipam_plugin)
+        self.plugin._find_ipam_plugin.return_value = plugin_path
+
+        # Mock out return values.
+        ip4 = "10.0.0.1/32"
+        ip6 = "0:0:0:0:0:ffff:a00:1"
+        env = {}
+        out = json.dumps({"ip4": {"ip": ip4}, "ip6": {"ip": ip6}})
+        m_call_bin.return_value = 0, out
+
+        # Set IPAM type.
+        self.plugin.ipam_type = "host-local"
+        self.plugin.network_config["ipam"]["subnet"] = "usePodCidr"
+        self.plugin.kubeconfig_path = "/path/to/kubeconfig"
+        self.plugin.k8s_node_name = "nodename"
+
+        # Setup response.
+        node = MagicMock(obj={"metadata": {"name": "nodename"}, "spec":{"podCIDR": ""}})
+        nodes = [node]
+        m_node.objects.return_value = nodes
+
+        with assert_raises(SystemExit) as err:
+            self.plugin._call_ipam_plugin(env)
+        e = err.exception
+        assert_equal(e.code, ERR_CODE_GENERIC)
+
+    def test_get_pod_cidr_no_kcfg(self):
+        with assert_raises(SystemExit) as err:
+            self.plugin._get_kubernetes_pod_cidr()
+        e = err.exception
+        assert_equal(e.code, ERR_CODE_GENERIC)
+
+    @patch("calico.HTTPClient", autospec=True)
+    @patch("calico.Node", autospec=True)
+    @patch("calico.KubeConfig", autospec=True)
+    def test_get_pod_cidr_no_node_in_api(self, m_kcfg, m_node, m_http):
+        # Set IPAM type.
+        self.plugin.ipam_type = "host-local"
+        self.plugin.network_config["ipam"]["subnet"] = "usePodCidr"
+        self.plugin.kubeconfig_path = "/path/to/kubeconfig"
+        self.plugin.k8s_node_name = "nodename"
+
+        # Setup response.
+        m_node.objects.return_value = []
+
+        with assert_raises(SystemExit) as err:
+            self.plugin._get_kubernetes_pod_cidr()
+        e = err.exception
+        assert_equal(e.code, ERR_CODE_GENERIC)


### PR DESCRIPTION
- Support kubeconfig as means of accessing / authenticating with API server.
- Read podCidr from k8s API when using host-local IPAM with `subnet: usePodCidr`