### PR TITLE
Switch Kubernetes version from 1.1.3 to 1.3.0

### DIFF
--- a/samples/kubernetes/cloud-config/master-config-template.yaml
+++ b/samples/kubernetes/cloud-config/master-config-template.yaml
@@ -20,8 +20,8 @@ write_files:
         echo "Kubenetes not installed - installing."
 
         # Extract the Kubernetes binaries.
-        sudo wget -N -P /opt/bin http://storage.googleapis.com/kubernetes-release/release/v1.1.3/bin/linux/amd64/kubectl
-        sudo wget -N -P /opt/bin http://storage.googleapis.com/kubernetes-release/release/v1.1.3/bin/linux/amd64/kubelet
+        sudo wget -N -P /opt/bin http://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubectl
+        sudo wget -N -P /opt/bin http://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubelet
         sudo chmod +x /opt/bin/kubelet /opt/bin/kubectl
       fi
 
@@ -58,9 +58,9 @@ write_files:
         echo "Manifests not installed - installing."
 
         # Download config.
-        sudo wget -N -P /etc/kubernetes/manifests/ https://raw.githubusercontent.com/projectcalico/calico-cni/k8s-1.1-docs/samples/kubernetes/master/kubernetes-master.manifest
-        sudo wget -N -P /etc/kubernetes/manifests/ https://raw.githubusercontent.com/projectcalico/calico-cni/k8s-1.1-docs/samples/kubernetes/master/calico-etcd.manifest
-        sudo wget -N -P /etc/kubernetes/addons/ https://raw.githubusercontent.com/projectcalico/calico-cni/k8s-1.1-docs/samples/kubernetes/master/dns/skydns.yaml
+        sudo wget -N -P /etc/kubernetes/manifests/ https://raw.githubusercontent.com/projectcalico/calico-cni/k8s-1.3-docs/samples/kubernetes/master/kubernetes-master.manifest
+        sudo wget -N -P /etc/kubernetes/manifests/ https://raw.githubusercontent.com/projectcalico/calico-cni/k8s-1.3-docs/samples/kubernetes/master/calico-etcd.manifest
+        sudo wget -N -P /etc/kubernetes/addons/ https://raw.githubusercontent.com/projectcalico/calico-cni/k8s-1.3-docs/samples/kubernetes/master/dns/skydns.yaml
       fi
 
       # Insert the master's IP address into the manifest.

--- a/samples/kubernetes/cloud-config/node-config-template.yaml
+++ b/samples/kubernetes/cloud-config/node-config-template.yaml
@@ -35,7 +35,7 @@ write_files:
         echo "Kubenetes not installed - installing."
 
         # Extract the Kubernetes binaries.
-        sudo wget -N -P /opt/bin http://storage.googleapis.com/kubernetes-release/release/v1.1.3/bin/linux/amd64/kubelet
+        sudo wget -N -P /opt/bin http://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubelet
         sudo chmod +x /opt/bin/kubelet
 
         # Create required folders
@@ -149,7 +149,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-proxy
-          image: gcr.io/google_containers/hyperkube:v1.1.3
+          image: gcr.io/google_containers/hyperkube:v1.3.0
           command:
           - /hyperkube
           - proxy

--- a/samples/kubernetes/master/kubernetes-master.manifest
+++ b/samples/kubernetes/master/kubernetes-master.manifest
@@ -41,7 +41,7 @@ spec:
           name: "etcd-datadir"
 
     - name: kube-apiserver
-      image: gcr.io/google_containers/hyperkube:v1.1.3
+      image: gcr.io/google_containers/hyperkube:v1.3.0
       command: 
         - /hyperkube
         - apiserver
@@ -76,7 +76,7 @@ spec:
           name: "var-run-kubernetes"
 
     - name: kube-controller-manager
-      image: gcr.io/google_containers/hyperkube:v1.1.3
+      image: gcr.io/google_containers/hyperkube:v1.3.0
       command:
       - /hyperkube
       - controller-manager
@@ -99,7 +99,7 @@ spec:
         readOnly: true
 
     - name: kube-scheduler
-      image: gcr.io/google_containers/hyperkube:v1.1.3
+      image: gcr.io/google_containers/hyperkube:v1.3.0
       command:
       - /hyperkube
       - scheduler
@@ -113,7 +113,7 @@ spec:
         timeoutSeconds: 1
 
     - name: kube-proxy
-      image: gcr.io/google_containers/hyperkube:v1.1.3
+      image: gcr.io/google_containers/hyperkube:v1.3.0
       command:
       - /hyperkube
       - proxy

--- a/samples/kubernetes/node/kube-proxy.manifest
+++ b/samples/kubernetes/node/kube-proxy.manifest
@@ -6,7 +6,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: gcr.io/google_containers/hyperkube:v1.1.3
+    image: gcr.io/google_containers/hyperkube:v1.3.0
     command:
     - /hyperkube
     - proxy


### PR DESCRIPTION
Now that 1.3.0 is released.

The changes to ` samples/kubernetes/cloud-config/master-config-template.yaml` include an assumption that this new content will be tagged `k8s-1.3-docs` (like the current content is tagged `k8s-1.1-docs`).