### PR TITLE
Update Calico version, add policy-controller to samples.

### DIFF
--- a/samples/kubernetes/cloud-config/master-config-template.yaml
+++ b/samples/kubernetes/cloud-config/master-config-template.yaml
@@ -35,12 +35,12 @@ write_files:
         echo "Calico not installed - installing."
        
         # Install the `calicoctl` binary
-        wget https://github.com/projectcalico/calico-containers/releases/download/v0.14.0/calicoctl
+        wget https://github.com/projectcalico/calico-containers/releases/download/v0.20.0/calicoctl
         chmod +x calicoctl
         sudo mv calicoctl /opt/bin
 
         # Fetch the calico/node container
-        sudo docker pull calico/node:v0.14.0
+        sudo docker pull calico/node:v0.20.0
       fi
 
   - path: /opt/bin/install-manifests.sh
@@ -67,6 +67,31 @@ write_files:
       echo "DEFAULT_IPV4: $DEFAULT_IPV4"
       sudo sed -i -e "s/<MASTER_IPV4>/$DEFAULT_IPV4/g" /etc/kubernetes/manifests/calico-etcd.manifest
 
+  - path: /etc/kubernetes/manifests/policy-controller.manifest
+    owner: root
+    permissions: 0755
+    content: |
+      apiVersion: v1
+      kind: Pod 
+      metadata:
+        name: policy-controller
+        namespace: kube-system 
+        labels:
+          projectcalico.org/app: "policy-controller"
+      spec:
+        hostNetwork: true
+        containers:
+          # The Calico policy controller.
+          - name: policy-controller 
+            image: calico/kube-policy-controller:v0.2.0
+            env:
+              # Modify ETCD_ENDPOINTS to match your etcd cluster.
+              - name: ETCD_ENDPOINTS
+                value: "http://127.0.0.1:2379"
+              - name: K8S_API
+                value: "http://127.0.0.1:8080"
+              - name: LEADER_ELECTION 
+                value: "false"
 coreos:
   update:
     reboot-strategy: off

--- a/samples/kubernetes/cloud-config/node-config-template.yaml
+++ b/samples/kubernetes/cloud-config/node-config-template.yaml
@@ -54,17 +54,17 @@ write_files:
         echo "Calico not installed - installing."
        
         # Install the `calicoctl` binary
-        wget https://github.com/projectcalico/calico-docker/releases/download/v0.14.0/calicoctl
+        wget https://github.com/projectcalico/calico-docker/releases/download/v0.20.0/calicoctl
         chmod +x calicoctl
         sudo mv calicoctl /opt/bin
 
         # Fetch the calico/node container
-        sudo docker pull calico/node:v0.14.0
+        sudo docker pull calico/node:v0.20.0
 
         # Install the CNI plugin.
         sudo mkdir -p /opt/cni/bin/
-        sudo wget -N -P /opt/cni/bin/ https://github.com/projectcalico/calico-cni/releases/download/v1.0.0/calico
-        sudo wget -N -P /opt/cni/bin/ https://github.com/projectcalico/calico-cni/releases/download/v1.0.0/calico-ipam
+        sudo wget -N -P /opt/cni/bin/ https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico
+        sudo wget -N -P /opt/cni/bin/ https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico-ipam
         sudo chmod +x /opt/cni/bin/calico /opt/cni/bin/calico-ipam
       fi
 

--- a/samples/kubernetes/master/policy-controller.manifest
+++ b/samples/kubernetes/master/policy-controller.manifest
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod 
+metadata:
+  name: policy-controller
+  namespace: kube-system 
+  labels:
+    projectcalico.org/app: "policy-controller"
+spec:
+  hostNetwork: true
+  containers:
+    # The Calico policy controller.
+    - name: policy-controller 
+      image: calico/kube-policy-controller:v0.2.0
+      env:
+        # Modify ETCD_ENDPOINTS to match your etcd cluster.
+        - name: ETCD_ENDPOINTS
+          value: "http://127.0.0.1:2379"
+        - name: K8S_API
+          value: "http://127.0.0.1:8080"
+        - name: LEADER_ELECTION 
+          value: "false"


### PR DESCRIPTION
@tomdee - I believe we're eventually moving these samples somewhere else, but for now these are the required changes for k8s v1.3.0 and policy.  I'd like to merge them so they are up to date and I can update the upstream k8s install guides.