### PR TITLE
Remove kube-system from skydns manifest

### DIFF
--- a/samples/kubernetes/master/dns/skydns.yaml
+++ b/samples/kubernetes/master/dns/skydns.yaml
@@ -1,11 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: kube-system
-
----
-
-apiVersion: v1
 kind: Service
 metadata:
   name: kube-dns


### PR DESCRIPTION
Fixes #118 

v1.3.0 Kubernetes automatically creates the kube-system namespace, so we don't need to do it anymore.