### PR TITLE
Install on Kubernetes using DaemonSet.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,15 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:/opt/cni/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 RUN mkdir -p /opt/cni/bin
 
+# Add source files.
 ADD glide.yaml glide.lock Makefile /go/src/github.com/projectcalico/calico-cni/
 ADD *.go /go/src/github.com/projectcalico/calico-cni/
 ADD utils /go/src/github.com/projectcalico/calico-cni/utils
 ADD ipam /go/src/github.com/projectcalico/calico-cni/ipam
 ADD k8s /go/src/github.com/projectcalico/calico-cni/k8s
+
+# Add CNI install script.
+ADD ./k8s-install/scripts/install-cni.sh /install-cni.sh
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ all: vendor build-containerized test-containerized
 binary:  plugin ipam
 plugin: dist/calico
 ipam: dist/calico-ipam
+docker-image: $(DEPLOY_CONTAINER_MARKER)
 
 .PHONY: clean
 clean:

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Script to install Calico CNI on a Kubernetes host.
+# - Expects the host CNI binary path to be mounted at /host/opt/cni/bin.
+# - Expects the host CNI network config path to be mounted at /host/etc/cni/net.d.
+# - Expects the desired CNI config in the CNI_NETWORK_CONFIG env variable.
+
+# Ensure all variables are defined.
+set -u
+
+# Clean up any existing binaries. 
+rm -f /host/opt/cni/bin/calico /host/opt/cni/bin/calico-ipam
+
+# Place the new binaries.
+cp /opt/cni/bin/calico /host/opt/cni/bin/calico
+cp /opt/cni/bin/calico-ipam /host/opt/cni/bin/calico-ipam
+echo "Wrote Calico CNI binaries to /host/opt/cni/bin/"
+echo "CNI plugin version: $(/host/opt/cni/bin/calico -v)"
+
+# Make the network configuration file.
+cat >/host/etc/cni/net.d/10-calico.conf <<EOF
+${CNI_NETWORK_CONFIG}
+EOF
+
+echo "Wrote CNI config: $(cat /host/etc/cni/net.d/10-calico.conf)"
+
+# Unless told otherwise, sleep forever.
+# This prevents Kubernetes from restarting the pod repeatedly.
+should_sleep=${SLEEP:-"true"}
+echo "Done configuring CNI.  Sleep=$should_sleep"
+while [ "$should_sleep" == "true"  ]; do
+	sleep 1;
+done


### PR DESCRIPTION
This updates the `calico/cni` container to include functionality required for Kubernetes self-hosted installation.

Allows a Kubernetes DaemonSet to deploy the Calico CNI binaries, as well as a CNI network config file to each node in the cluster. 
