### PR TITLE
Golang fixes

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -31,7 +31,6 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/projectcalico/calico-cni/k8s"
 	. "github.com/projectcalico/calico-cni/utils"
-	"github.com/satori/go.uuid"
 	"github.com/tigera/libcalico-go/lib/api"
 	"github.com/tigera/libcalico-go/lib/errors"
 	cnet "github.com/tigera/libcalico-go/lib/net"
@@ -128,10 +127,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 			// 2) Create the endpoint object
 			endpoint = api.NewWorkloadEndpoint()
+			endpoint.Metadata.Name = args.IfName
 			endpoint.Metadata.Hostname = hostname
 			endpoint.Metadata.OrchestratorID = orchestratorID
 			endpoint.Metadata.WorkloadID = workloadID
-			endpoint.Metadata.Name = fmt.Sprintf("%x", uuid.NewV1())
 			endpoint.Spec.Profiles = []string{profileID}
 
 			if err = PopulateEndpointNets(endpoint, result); err != nil {

--- a/calico.go
+++ b/calico.go
@@ -33,7 +33,8 @@ import (
 	. "github.com/projectcalico/calico-cni/utils"
 	"github.com/satori/go.uuid"
 	"github.com/tigera/libcalico-go/lib/api"
-	"github.com/tigera/libcalico-go/lib/common"
+	"github.com/tigera/libcalico-go/lib/errors"
+	cnet "github.com/tigera/libcalico-go/lib/net"
 )
 
 var hostname string
@@ -150,7 +151,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				return err
 			}
 
-			endpoint.Spec.MAC = common.MAC{HardwareAddr: mac}
+			endpoint.Spec.MAC = cnet.MAC{HardwareAddr: mac}
 			endpoint.Spec.InterfaceName = hostVethName
 		}
 
@@ -167,7 +168,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		exists := true
 		_, err = calicoClient.Profiles().Get(api.ProfileMetadata{Name: conf.Name})
 		if err != nil {
-			_, ok := err.(common.ErrorResourceDoesNotExist)
+			_, ok := err.(errors.ErrorResourceDoesNotExist)
 			if ok {
 				exists = false
 			} else {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 948daa21c3ba00b20f0d2b84d6a2e875a1c86af74c795b248d2a13fe82549109
-updated: 2016-08-04T10:07:17.313871772-07:00
+updated: 2016-08-05T10:46:09.013060942-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
@@ -245,7 +245,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 - name: github.com/tigera/libcalico-go
-  version: 0da7f2c70f1fc610466e76bda4fc1be50251e2c6
+  version: 372ebe73277d4b6c9138c666939c0d8442c20f3e
   subpackages:
   - lib/api
   - lib/errors

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 948daa21c3ba00b20f0d2b84d6a2e875a1c86af74c795b248d2a13fe82549109
-updated: 2016-07-28T14:06:33.5790698-07:00
+updated: 2016-08-04T10:07:17.313871772-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
@@ -10,13 +10,14 @@ imports:
 - name: github.com/cloudfoundry-incubator/candiedyaml
   version: 99c3df83b51532e3615f851d8c2dbb638f5313bf
 - name: github.com/containernetworking/cni
-  version: c1ff202179dc15839825bed39e59d40b1c08a469
+  version: 7c579af7898c2e50fc02de711e031408450979a3
   subpackages:
   - pkg/ip
   - pkg/ipam
   - pkg/ns
   - pkg/skel
   - pkg/types
+  - pkg/utils/hwaddr
   - pkg/invoke
 - name: github.com/coreos/etcd
   version: 8b320e7c550067b1dfb37bd1682e8067023e0751
@@ -244,14 +245,21 @@ imports:
 - name: github.com/spf13/pflag
   version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 - name: github.com/tigera/libcalico-go
-  version: c30ea3cd594d01657f3f9fd22b176386fd042daf
+  version: 0da7f2c70f1fc610466e76bda4fc1be50251e2c6
   subpackages:
   - lib/api
-  - lib/common
+  - lib/errors
+  - lib/net
   - lib/client
   - lib/api/unversioned
-  - lib/selector
+  - lib/backend/etcd
+  - lib/numorstring
+  - lib/validator
   - lib/backend
+  - lib/backend/api
+  - lib/backend/model
+  - lib/selector
+  - lib/backend/compat
   - lib/selector/parser
   - lib/hash
   - lib/selector/tokenizer
@@ -310,7 +318,7 @@ imports:
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: k8s.io/kubernetes
-  version: e7f022c926583ed8e755a52f23abc4cf8b532d12
+  version: a0bfee0d3899d2b91530552a536405c1fe1a1d2a
   subpackages:
   - pkg/api
   - pkg/client/restclient

--- a/ipam/calico-ipam.go
+++ b/ipam/calico-ipam.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/projectcalico/calico-cni/utils"
 	"github.com/tigera/libcalico-go/lib/client"
-	"github.com/tigera/libcalico-go/lib/common"
+	cnet "github.com/tigera/libcalico-go/lib/net"
 )
 
 func main() {
@@ -53,7 +53,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		fmt.Fprintf(os.Stderr, "Calico CNI IPAM request IP: %v\n", ipamArgs.IP)
 
 		// The hostname will be defaulted to the actual hostname if cong.Hostname is empty
-		assignArgs := client.AssignIPArgs{IP: common.IP{ipamArgs.IP}, HandleID: &workloadID, Hostname: &conf.Hostname}
+		assignArgs := client.AssignIPArgs{IP: cnet.IP{ipamArgs.IP}, HandleID: &workloadID, Hostname: conf.Hostname}
 		err := calicoClient.IPAM().AssignIP(assignArgs)
 		if err != nil {
 			return err
@@ -76,7 +76,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 		fmt.Fprintf(os.Stderr, "Calico CNI IPAM request count IPv4=%d IPv6=%d\n", num4, num6)
 
-		assignArgs := client.AutoAssignArgs{Num4: num4, Num6: num6, HandleID: &args.ContainerID, Hostname: &conf.Hostname}
+		assignArgs := client.AutoAssignArgs{Num4: num4, Num6: num6, HandleID: &args.ContainerID, Hostname: conf.Hostname}
 		assignedV4, assignedV6, err := calicoClient.IPAM().AutoAssign(assignArgs)
 		fmt.Fprintf(os.Stderr, "Calico CNI IPAM assigned addresses IPv4=%v IPv6=%v\n", assignedV4, assignedV6)
 		if err != nil {

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/projectcalico/calico-cni/utils"
 	"github.com/tigera/libcalico-go/lib/api"
-	"github.com/tigera/libcalico-go/lib/common"
+	cnet "github.com/tigera/libcalico-go/lib/net"
 
 	"encoding/json"
 
@@ -112,7 +112,7 @@ func CmdAddK8s(args *skel.CmdArgs, conf utils.NetConf, hostname string, calicoCl
 	if err != nil {
 		return nil, err
 	}
-	endpoint.Spec.MAC = common.MAC{HardwareAddr: mac}
+	endpoint.Spec.MAC = cnet.MAC{HardwareAddr: mac}
 	endpoint.Spec.InterfaceName = hostVethName
 
 	// Write the endpoint object (either the newly created one, or the updated one)

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"os"
 
@@ -128,8 +129,14 @@ func newK8sClient(conf utils.NetConf) (*k8sclient.Client, error) {
 	// Some config can be passed in a kubeconfig file
 	kubeconfig := conf.Kubernetes.Kubeconfig
 
-	// but that config can be overridden by config passed in explicitly in the network config.
+	// Config can be overridden by config passed in explicitly in the network config.
 	configOverrides := &clientcmd.ConfigOverrides{}
+
+	// If an API root is given, make sure we're using using the name / port rather than
+	// the full URL. Earlier versions of the config required the full `/api/v1/` extension,
+	// so split that off to ensure compatibility.
+	conf.Policy.K8sAPIRoot = strings.Split(conf.Policy.K8sAPIRoot, "/api/")[0]
+
 	var overridesMap = []struct {
 		variable *string
 		value    string

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -83,6 +83,7 @@ func CmdAddK8s(args *skel.CmdArgs, conf utils.NetConf, hostname string, calicoCl
 
 		// Create the endpoint object and configure it
 		endpoint = api.NewWorkloadEndpoint()
+		endpoint.Metadata.Name = args.IfName
 		endpoint.Metadata.Hostname = hostname
 		endpoint.Metadata.OrchestratorID = orchestratorID
 		endpoint.Metadata.WorkloadID = workloadID

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -50,9 +50,10 @@ func CreateResultFromEndpoint(ep *api.WorkloadEndpoint) (*types.Result, error) {
 	result := &types.Result{}
 
 	for _, v := range ep.Spec.IPNetworks {
-		unparsedIP := fmt.Sprintf(`{"ip": "%s"}`, v)
+		unparsedIP := fmt.Sprintf(`{"ip": "%s"}`, v.String())
 		parsedIP := types.IPConfig{}
 		if err := parsedIP.UnmarshalJSON([]byte(unparsedIP)); err != nil {
+			glog.Errorf("Error unmarshalling existing endpoint IP: %s", err)
 			return nil, err
 		}
 


### PR DESCRIPTION
Contains a few distinct commits:

- Update to latest libcalico to pick up various fixes there.
- Use the container ifname as the endpoint ID rather than a randomly generated value.
- Compatibility with the old-style k8s_api_root variable.