### PR TITLE
Fix nil labels field getting into etcd when not using k8s policy

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -101,6 +101,7 @@ func CmdAddK8s(args *skel.CmdArgs, conf utils.NetConf, hostname string, calicoCl
 		endpoint.Metadata.Hostname = hostname
 		endpoint.Metadata.OrchestratorID = orchestratorID
 		endpoint.Metadata.WorkloadID = workloadID
+		endpoint.Metadata.Labels = make(map[string]string)
 
 		// Set the profileID according to whether Kubernetes policy is required. If it's not, then just use the network
 		// name (which is the normal behavior) otherwise use one based on the Kubernetes pod's Mamespace.


### PR DESCRIPTION
If the policy type isn't "k8s" the endpoint labels metadata never gets initialised and ends up as null in etcd. It looks like this causes some issues when felix tries to read from it. Making sure it's initialised fixes this.

Spoken to @caseydavenport and he mentioned this used to be handle in https://github.com/projectcalico/calico-cni/blob/master/k8s/k8s.go#L222 but https://github.com/projectcalico/calico-cni/commit/34577483abe1d69c410657c9a44ae11dff46bbd9#diff-b396ca928d5bd0e161acd283b56ead9fL121 made this optional and inadvertently introduced the bug.