### PR TITLE
Use new location of 'libcalico-go' repository

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -32,9 +32,9 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/projectcalico/calico-cni/k8s"
 	. "github.com/projectcalico/calico-cni/utils"
-	"github.com/tigera/libcalico-go/lib/api"
-	"github.com/tigera/libcalico-go/lib/errors"
-	cnet "github.com/tigera/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
 var hostname string

--- a/glide.lock
+++ b/glide.lock
@@ -110,8 +110,8 @@ imports:
   version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
 - name: github.com/spf13/pflag
   version: 6fd2ff4ff8dfcdf5556fbdc0ac0284408274b1a7
-- name: github.com/tigera/libcalico-go
-  version: 658ba00cbe61fa2a1a61bf3c85505b6ce28251f6
+- name: github.com/projectcalico/libcalico-go
+  version: 0ddf9de2807feb4ef2953d78fab33e0bc78d2fdb
   subpackages:
   - lib/api
   - lib/api/unversioned

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,7 +13,7 @@ import:
 - package: github.com/onsi/gomega
   subpackages:
   - gexec
-- package: github.com/tigera/libcalico-go
+- package: github.com/projectcalico/libcalico-go
   subpackages:
   - lib/api
   - lib/client

--- a/ipam/calico-ipam.go
+++ b/ipam/calico-ipam.go
@@ -12,8 +12,8 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/projectcalico/calico-cni/utils"
-	"github.com/tigera/libcalico-go/lib/client"
-	cnet "github.com/tigera/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/client"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
 func main() {

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -11,8 +11,8 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/projectcalico/calico-cni/utils"
-	"github.com/tigera/libcalico-go/lib/api"
-	cnet "github.com/tigera/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/api"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
 
 	"encoding/json"
 
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/1.4/tools/clientcmd"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/tigera/libcalico-go/lib/client"
+	"github.com/projectcalico/libcalico-go/lib/client"
 )
 
 // CmdAddK8s performs the "ADD" operation on a kubernetes pod

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -16,9 +16,9 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/golang/glog"
-	"github.com/tigera/libcalico-go/lib/api"
-	"github.com/tigera/libcalico-go/lib/client"
-	cnet "github.com/tigera/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/client"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
 func min(a, b int) int {


### PR DESCRIPTION
Replace 'tigera/libcalico-go' by 'projectcalico/libcalico-go'.

Pin 'libcalico-go' to the following commit: https://github.com/projectcalico/libcalico-go/commit/0ddf9de2807feb4ef2953d78fab33e0bc78d2fdb

Change-Id: I3c835051b5cf781a78fd3ac26b86a952ac5ae067