### PR TITLE
Check for number of returned IPs from IPAM

### DIFF
--- a/ipam/calico-ipam.go
+++ b/ipam/calico-ipam.go
@@ -88,11 +88,17 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 
 		if num4 == 1 {
+			if len(assignedV4) != num4 {
+				return fmt.Errorf("Failed to request %d IPv4 addresses. IPAM allocated only %d.", num4, len(assignedV4))
+			}
 			ipV4Network := net.IPNet{IP: assignedV4[0].IP, Mask: net.CIDRMask(32, 32)}
 			r.IP4 = &types.IPConfig{IP: ipV4Network}
 		}
 
 		if num6 == 1 {
+			if len(assignedV6) != num6 {
+				return fmt.Errorf("Failed to request %d IPv6 addresses. IPAM allocated only %d.", num6, len(assignedV6))
+			}
 			ipV6Network := net.IPNet{IP: assignedV6[0].IP, Mask: net.CIDRMask(128, 128)}
 			r.IP6 = &types.IPConfig{IP: ipV6Network}
 		}


### PR DESCRIPTION
Current implementation of libcalico-go does not return any error if
no IPs were allocated. This patch fixes a crash listed in the bug
report.
There is a consideration to return an error from libcalico-go, if no
or not all requested IPs were allocated. Please see details here:
https://github.com/projectcalico/libcalico-go/issues/202

Closes #188