### PR TITLE
Use local 'libcalico-go' for containerized build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ BUILD_CONTAINER_MARKER=cni_build_container.created
 DEPLOY_CONTAINER_NAME=calico/cni
 DEPLOY_CONTAINER_MARKER=cni_deploy_container.created
 
+LIBCALICOGO_PATH?=none
+
 .PHONY: all binary plugin ipam
 default: all
 all: vendor build-containerized test-containerized
@@ -34,7 +36,10 @@ vendor:
 	glide install -strip-vcs -strip-vendor --cache
 
 vendor-containerized:
-	docker run --rm -v ${PWD}:/go/src/github.com/projectcalico/calico-cni:rw \
+	if [ "$(LIBCALICOGO_PATH)" != "none" ]; then \
+          EXTRA_DOCKER_BIND="-v $(LIBCALICOGO_PATH):/go/src/github.com/projectcalico/libcalico-go:ro"; \
+	fi; \
+	docker run --rm -v ${PWD}:/go/src/github.com/projectcalico/calico-cni:rw $$EXTRA_DOCKER_BIND \
         $(GO_CONTAINER_NAME) /bin/bash -c ' \
 	cd /go/src/github.com/projectcalico/calico-cni; \
 	glide install -strip-vcs -strip-vendor --cache; \


### PR DESCRIPTION
Add a possibility to use custom 'libcalico-go' repo
location while building binaries inside container:

 - bind additional directory with local copy of the
   repository to '/go/src/github.com/projectcalico/libcalico-go'
   folder inside Docker container;
 - modify 'glide.lock', so 'libcalico-go' module is
   taken from local path when binary is built within container
   'repo: file:///go/src/github.com/projectcalico/libcalico-go'.

With this change it's possible to build CNI binaries and
test them in order to verify changes to the 'libcalico-go'.

Change-Id: Id8466eed7f86c4870fbba35fe6d12872678dc45e