### PR TITLE
Updated ref libcalico-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -104,7 +104,7 @@ imports:
 - name: github.com/pborman/uuid
   version: 3d4f2ba23642d3cfd06bd4b54cf03d99d95c0f1b
 - name: github.com/projectcalico/libcalico-go
-  version: 4d86b6458df42f96e0ac15f6a4130884376d6f02
+  version: d6ce86635949b276b53b325faf791e98b9b1643a
   subpackages:
   - lib/api
   - lib/api/unversioned


### PR DESCRIPTION
libcalico-go git history seems to be rewritten, so tests do not pass
anymore. Updating ref to the latest patches, before serious changes
were introduced (e.g. remove calicoctl).
We need to get this build green first, and then make a further update
here to point to the latest libcalico-go version.

This patch should fix tests failing in #190.