### PR TITLE
Adding CNI binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@
 !k8s-install/scripts/install-cni.sh
 !dist/calico
 !dist/calico-ipam
+!dist/flannel
+!dist/loopback
+!dist/host-local

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ addstats
 delstats
 *.pyc
 *.created
+tmp-cni

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM busybox
 MAINTAINER Tom Denham <tom@tigera.io>
 
 ADD dist/calico /opt/cni/bin/calico
+ADD dist/flannel /opt/cni/bin/flannel
+ADD dist/loopback /opt/cni/bin/loopback
+ADD dist/host-local /opt/cni/bin/host-local
 ADD dist/calico-ipam /opt/cni/bin/calico-ipam
 ADD k8s-install/scripts/install-cni.sh /install-cni.sh
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ BUILD_CONTAINER_NAME=calico/cni_build_container
 BUILD_CONTAINER_MARKER=cni_build_container.created
 DEPLOY_CONTAINER_NAME=calico/cni
 DEPLOY_CONTAINER_MARKER=cni_deploy_container.created
-TEMP_DIR:=$(shell mktemp -d)
 
 LIBCALICOGO_PATH?=none
 
@@ -89,23 +88,21 @@ test-watch: dist/calico dist/calico-ipam
 	# The tests need to run as root
 	sudo CGO_ENABLED=0 ETCD_IP=127.0.0.1 PLUGIN=calico GOPATH=$(GOPATH) $(shell which ginkgo) watch
 
-$(BUILD_CONTAINER_MARKER): Dockerfile.build
-	mkdir -p dist
-	curl -sSL --retry 5 https://github.com/containernetworking/cni/releases/download/v0.3.0/cni-v0.3.0.tgz | tar -xz -C $(TEMP_DIR)
-	mv ${TEMP_DIR}/flannel dist/flannel
-	mv ${TEMP_DIR}/loopback dist/loopback
-	mv ${TEMP_DIR}/host-local dist/host-local
+$(BUILD_CONTAINER_MARKER): Dockerfile.build fetch-cni-bins
 	docker build -f Dockerfile.build -t $(BUILD_CONTAINER_NAME) .
 	touch $@
 
-$(DEPLOY_CONTAINER_MARKER): Dockerfile build-containerized
-	mkdir -p dist
-	curl -sSL --retry 5 https://github.com/containernetworking/cni/releases/download/v0.3.0/cni-v0.3.0.tgz | tar -xz -C $(TEMP_DIR)
-	mv ${TEMP_DIR}/flannel dist/flannel
-	mv ${TEMP_DIR}/loopback dist/loopback
-	mv ${TEMP_DIR}/host-local dist/host-local
+$(DEPLOY_CONTAINER_MARKER): Dockerfile build-containerized fetch-cni-bins
 	docker build -f Dockerfile -t $(DEPLOY_CONTAINER_NAME) .
 	touch $@
+
+.PHONY fetch-cni-bins:
+	mkdir -p tmp-cni
+	curl -sSL --retry 5 https://github.com/containernetworking/cni/releases/download/v0.3.0/cni-v0.3.0.tgz | tar -xz -C tmp-cni/
+	mv tmp-cni/flannel dist/flannel
+	mv tmp-cni/loopback dist/loopback
+	mv tmp-cni/host-local dist/host-local
+	rm -rf tmp-cni/
 
 # Run the tests in a container. Useful for CI
 .PHONY: test-containerized

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ BUILD_CONTAINER_NAME=calico/cni_build_container
 BUILD_CONTAINER_MARKER=cni_build_container.created
 DEPLOY_CONTAINER_NAME=calico/cni
 DEPLOY_CONTAINER_MARKER=cni_deploy_container.created
+TEMP_DIR:=$(shell mktemp -d)
 
 LIBCALICOGO_PATH?=none
 
@@ -89,10 +90,20 @@ test-watch: dist/calico dist/calico-ipam
 	sudo CGO_ENABLED=0 ETCD_IP=127.0.0.1 PLUGIN=calico GOPATH=$(GOPATH) $(shell which ginkgo) watch
 
 $(BUILD_CONTAINER_MARKER): Dockerfile.build
+	mkdir -p dist
+	curl -sSL --retry 5 https://github.com/containernetworking/cni/releases/download/v0.3.0/cni-v0.3.0.tgz | tar -xz -C $(TEMP_DIR)
+	mv ${TEMP_DIR}/flannel dist/flannel
+	mv ${TEMP_DIR}/loopback dist/loopback
+	mv ${TEMP_DIR}/host-local dist/host-local
 	docker build -f Dockerfile.build -t $(BUILD_CONTAINER_NAME) .
 	touch $@
 
 $(DEPLOY_CONTAINER_MARKER): Dockerfile build-containerized
+	mkdir -p dist
+	curl -sSL --retry 5 https://github.com/containernetworking/cni/releases/download/v0.3.0/cni-v0.3.0.tgz | tar -xz -C $(TEMP_DIR)
+	mv ${TEMP_DIR}/flannel dist/flannel
+	mv ${TEMP_DIR}/loopback dist/loopback
+	mv ${TEMP_DIR}/host-local dist/host-local
 	docker build -f Dockerfile -t $(DEPLOY_CONTAINER_NAME) .
 	touch $@
 

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -46,7 +46,7 @@ then
 fi
 
 # Place the new binaries.
-cp /opt/cni/bin/calico /host/opt/cni/bin/calico
+cp /opt/cni/bin/* /host/opt/cni/bin/
 cp /opt/cni/bin/calico-ipam /host/opt/cni/bin/calico-ipam
 echo "Wrote Calico CNI binaries to /host/opt/cni/bin/"
 echo "CNI plugin version: $(/host/opt/cni/bin/calico -v)"

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -47,7 +47,6 @@ fi
 
 # Place the new binaries.
 cp /opt/cni/bin/* /host/opt/cni/bin/
-cp /opt/cni/bin/calico-ipam /host/opt/cni/bin/calico-ipam
 echo "Wrote Calico CNI binaries to /host/opt/cni/bin/"
 echo "CNI plugin version: $(/host/opt/cni/bin/calico -v)"
 


### PR DESCRIPTION
Added host-local, loopback, and flannel CNI binaries, primarily to get Calico hosted deployment working with Hyperkube installs (e.g. CoreOS-k8s)