### PR TITLE
Fix version marker checks for make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ BUILD_CONTAINER_NAME=calico/cni_build_container
 BUILD_CONTAINER_MARKER=cni_build_container.created
 DEPLOY_CONTAINER_NAME=calico/cni
 DEPLOY_CONTAINER_MARKER=cni_deploy_container.created
-TEMP_DIR:=$(shell mktemp -d)
 
 LIBCALICOGO_PATH?=none
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ BUILD_CONTAINER_NAME=calico/cni_build_container
 BUILD_CONTAINER_MARKER=cni_build_container.created
 DEPLOY_CONTAINER_NAME=calico/cni
 DEPLOY_CONTAINER_MARKER=cni_deploy_container.created
+TEMP_DIR:=$(shell mktemp -d)
 
 LIBCALICOGO_PATH?=none
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 	# Check that the version output appears on a line of its own (the -x option to grep).
 # Tests that the "git tag" makes it into the binary. Main point is to catch "-dirty" builds
 	@echo "Checking if the tag made it into the binary"
-	dist/calico -v | grep -x $(VERSION) || echo "Reported version:" `dist/calico -v` "\nExpected version: $(VERSION)" && exit 1
+	dist/calico -v | grep -x $(VERSION) || ( echo "Reported version:" `dist/calico -v` "\nExpected version: $(VERSION)" && exit 1 )
 	docker tag $(DEPLOY_CONTAINER_NAME) $(DEPLOY_CONTAINER_NAME):$(VERSION)
 	docker tag $(DEPLOY_CONTAINER_NAME) quay.io/$(DEPLOY_CONTAINER_NAME):$(VERSION)
 


### PR DESCRIPTION
Check was always hitting the exit 1 causing it to fail