### PR TITLE
Builds/Tests: Remove calicoctl and etcdctl

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,20 +1,6 @@
-FROM golang:1.7-alpine
+FROM golang:1.7
 
 MAINTAINER Tom Denham <tom@tigera.io>
-
-# Install libc (to run calicoctl) and various build tools to build the vendored packages.
-ENV GLIBC_VERSION 2.23-r1
-RUN apk add --update bash git iproute2 curl make gcc alpine-sdk linux-headers && \
-  apk add --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing etcd && \
-  curl -o glibc.apk -L "https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" && \
-  apk add --allow-untrusted glibc.apk && \
-  curl -o glibc-bin.apk -L "https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" && \
-  apk add --allow-untrusted glibc-bin.apk && \
-  /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc/usr/lib && \
-  echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-  apk del curl && \
-  rm -f glibc.apk glibc-bin.apk && \
-  rm -rf /var/cache/apk/*
 
 RUN go get github.com/onsi/ginkgo/ginkgo
 WORKDIR /go/src/github.com/projectcalico/calico-cni

--- a/calico_cni_ipam_test.go
+++ b/calico_cni_ipam_test.go
@@ -14,8 +14,7 @@ var plugin = "calico-ipam"
 
 var _ = Describe("Calico IPAM Tests", func() {
 	BeforeEach(func() {
-		Cmd(fmt.Sprintf("etcdctl --endpoints http://%s:2379 rm /calico --recursive | true", os.Getenv("ETCD_IP")))
-
+		WipeEtcd()
 		PreCreatePool("192.168.0.0/16")
 		PreCreatePool("fd80:24e2:f998:72d6::/64")
 	})


### PR DESCRIPTION
Simplify the build by not relying on the calicoctl binary anymore
And simplify the tests by using libcalico-go for assertions